### PR TITLE
[BugFix] Pagination in QuizQuestions

### DIFF
--- a/apps/quiz-app/src/module/exam-result/dto/list-result.dto.ts
+++ b/apps/quiz-app/src/module/exam-result/dto/list-result.dto.ts
@@ -1,4 +1,4 @@
-import { PaginationQuery } from "@app/common/utils/pagination-helper";
+import { PaginationQuery } from "@app/common/utils/pagination";
 import { IsOptional, IsString } from "class-validator";
 
 export class ListResultQuery extends PaginationQuery {

--- a/apps/quiz-app/src/module/exam-result/exam-result.service.ts
+++ b/apps/quiz-app/src/module/exam-result/exam-result.service.ts
@@ -1,5 +1,5 @@
 import { Exam, ExamResult, User } from '@app/common/models';
-import { Pagination } from '@app/common/utils/pagination-helper';
+import { Pagination } from '@app/common/utils/pagination';
 import { HttpException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, Types } from 'mongoose';

--- a/apps/quiz-app/src/module/exam/dto/list-exams.dto.ts
+++ b/apps/quiz-app/src/module/exam/dto/list-exams.dto.ts
@@ -1,4 +1,4 @@
-import { PaginationQuery } from "@app/common/utils/pagination-helper";
+import { PaginationQuery } from "@app/common/utils/pagination";
 import { IsOptional, IsString } from "class-validator";
 
 export class ListExamQuery extends PaginationQuery {

--- a/apps/quiz-app/src/module/exam/exam.controller.ts
+++ b/apps/quiz-app/src/module/exam/exam.controller.ts
@@ -4,7 +4,7 @@ import { ListExamQuery } from './dto/list-exams.dto';
 import { HttpAuthGuard, ParseMonogoIdPipe, ProGuard } from '@app/common';
 import { QuestionService } from '../question/question.service';
 import { Types } from 'mongoose';
-import { PaginationQuery } from '@app/common/utils/pagination-helper';
+import { PaginationQuery } from '@app/common/utils/pagination';
 
 @Controller('exam')
 // @UseGuards(ProGuard) //TODO after implemnt payment

--- a/apps/quiz-app/src/module/exam/exam.service.ts
+++ b/apps/quiz-app/src/module/exam/exam.service.ts
@@ -1,5 +1,5 @@
 import { Exam } from '@app/common/models';
-import { Pagination } from '@app/common/utils/pagination-helper';
+import { Pagination } from '@app/common/utils/pagination';
 import { HttpException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, Types } from 'mongoose';

--- a/apps/quiz-app/src/module/playlist/dto/list-playlist.dto.ts
+++ b/apps/quiz-app/src/module/playlist/dto/list-playlist.dto.ts
@@ -1,4 +1,4 @@
-import { PaginationQuery } from "@app/common/utils/pagination-helper";
+import { PaginationQuery } from "@app/common/utils/pagination";
 import { IsOptional, IsString } from "class-validator";
 
 export class ListPlaylistQuery extends PaginationQuery {

--- a/apps/quiz-app/src/module/playlist/playlist.controller.ts
+++ b/apps/quiz-app/src/module/playlist/playlist.controller.ts
@@ -7,7 +7,7 @@ import { UserService } from '../user/user.service';
 import { CreatePalyListBody } from './dto/create-playlist.dto';
 import { UpdatePlaylistBody } from './dto/update-playlist.dto';
 import { QuestionService } from '../question/question.service';
-import { PaginationQuery } from '@app/common/utils/pagination-helper';
+import { PaginationQuery } from '@app/common/utils/pagination';
 
 @Controller('playlist')
 @UseGuards(HttpAuthGuard)

--- a/apps/quiz-app/src/module/playlist/playlist.service.ts
+++ b/apps/quiz-app/src/module/playlist/playlist.service.ts
@@ -1,5 +1,5 @@
 import { Playlist, Question, User } from '@app/common/models';
-import { Pagination } from '@app/common/utils/pagination-helper';
+import { Pagination } from '@app/common/utils/pagination';
 import { HttpException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, Types } from 'mongoose';

--- a/apps/quiz-app/src/module/question/question.service.ts
+++ b/apps/quiz-app/src/module/question/question.service.ts
@@ -1,5 +1,5 @@
 import { Exam, Question } from '@app/common/models';
-import { Pagination } from '@app/common/utils/pagination-helper';
+import { Pagination } from '@app/common/utils/pagination';
 import { HttpException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, Types } from 'mongoose';

--- a/apps/quiz-app/src/module/quiz/dto/list-quiz.dto.ts
+++ b/apps/quiz-app/src/module/quiz/dto/list-quiz.dto.ts
@@ -1,4 +1,4 @@
-import { PaginationQuery } from "@app/common/utils/pagination-helper";
+import { PaginationQuery } from "@app/common/utils/pagination";
 import { IsOptional, IsString } from "class-validator";
 
 export class ListQuizQuery extends PaginationQuery {

--- a/apps/quiz-app/src/module/quiz/quiz.service.ts
+++ b/apps/quiz-app/src/module/quiz/quiz.service.ts
@@ -1,6 +1,6 @@
 import { Question, User } from '@app/common/models';
 import { Quiz } from '@app/common/models/quiz.model';
-import { Pagination } from '@app/common/utils/pagination-helper';
+import { Pagination } from '@app/common/utils/pagination';
 import { HttpException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, Types } from 'mongoose';

--- a/libs/common/src/interceptors/response.interceptor.ts
+++ b/libs/common/src/interceptors/response.interceptor.ts
@@ -1,7 +1,7 @@
 import { Injectable, NestInterceptor, ExecutionContext, CallHandler, HttpException, HttpStatus } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { PaginationQuery } from '../utils/pagination-helper';
+import { PaginationQuery } from '../utils/pagination';
 
 interface Response {
   tokens?: { refreshToken: string, accessToken: string }

--- a/libs/common/src/utils/nested-pagination.ts
+++ b/libs/common/src/utils/nested-pagination.ts
@@ -1,0 +1,47 @@
+import { FilterQuery, Model } from "mongoose";
+
+export class NestedPagination<T> {
+
+    constructor(
+        private readonly model: T,
+        private readonly options?: {
+            page?: number;
+            limit?: number;
+        }
+    ) { }
+
+    getOptions() {
+
+        const page = this.options.page || 1;
+        const limit = this.options.limit || 10;
+        return {
+            page,
+            limit,
+            generate: async <T>(list: T[], total: number) =>
+                this.generate<T>(list, { page, limit, total })
+
+        }
+
+    }
+
+    private async generate<T>(list: T[], options: { page: number, limit: number, total: number }) {
+
+        const { page, limit, total } = options;
+
+
+        const currentPage = Math.min(page, Math.ceil(total / limit));
+
+        return {
+            pagination: {
+                page: currentPage || 0,
+                length: list.length,
+                next: total > currentPage * limit ? currentPage + 1 : undefined,
+                prev: currentPage > 1 ? currentPage - 1 : undefined,
+            },
+            data: list
+        }
+    }
+
+
+
+}

--- a/libs/common/src/utils/pagination.ts
+++ b/libs/common/src/utils/pagination.ts
@@ -1,6 +1,8 @@
 import { IsNumber, IsNumberString, IsOptional } from "class-validator";
 import { FilterQuery, Model } from "mongoose";
 
+
+
 export class Pagination<T> {
     constructor(
         private readonly model: Model<T>,
@@ -19,17 +21,18 @@ export class Pagination<T> {
         return {
             page,
             limit,
-            generate: async (list: T[]) => this.generate(list, { page, limit })
+            generate: async (list: T[]) => {
+                const total = await this.model.countDocuments(this.options.filter || {});
+                return this.generate(list, { page, limit, total });
+            }
         }
 
     }
 
-    private async generate<T>(list: T[], options: { page: number, limit: number }) {
+    private async generate<T>(list: T[], options: { page: number, limit: number, total: number }) {
 
-        const { page, limit } = options;
+        const { page, limit, total } = options;
 
-
-        const total = await this.model.countDocuments(this.options.filter);
 
         const currentPage = Math.min(page, Math.ceil(total / limit));
 


### PR DESCRIPTION
Updated various modules in the quiz-app and common library to use a streamlined `pagination` utility instead of `pagination-helper`, aligning with a project-wide initiative to standardize utility usage. This change simplifies import paths and increases code maintainability by consolidating pagination-related functionalities into one source. The update affects DTOs, services, and controllers across quiz, exam, playlist, and question modules, ensuring consistency in how pagination is invoked. In the quiz controller, expanded the response structure to better encapsulate pagination details and quiz data, enhancing the API response readability and utility for frontend consumption.