### PR TITLE
[BugFix] Get questions in quizz

### DIFF
--- a/apps/quiz-app/src/module/question/dto/list-questions.dto.ts
+++ b/apps/quiz-app/src/module/question/dto/list-questions.dto.ts
@@ -14,7 +14,7 @@ class Field {
     course: string;
 }
 
-export class ListQuestionsBody {
+export class ListQuestionsQuery extends PaginationQuery {
     @IsOptional()
     @IsEnum(['QCM', 'QCU'], { each: true })
     types?: ('QCM' | 'QCU')[];
@@ -36,11 +36,9 @@ export class ListQuestionsBody {
     @IsBoolean()
     withExplanation?: boolean;
 
-}
-
-
-export class ListQuestionsQuery extends PaginationQuery {
     @IsOptional()
     @IsString()
     keywords?: string;
 }
+
+

--- a/apps/quiz-app/src/module/question/question.controller.ts
+++ b/apps/quiz-app/src/module/question/question.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { QuestionService } from './question.service';
 import { QuestionFilter } from './interface/question-filter';
-import { ListQuestionsBody, ListQuestionsQuery } from './dto/list-questions.dto';
+import { ListQuestionsQuery } from './dto/list-questions.dto';
 import { ExamService } from '../exam/exam.service';
 import { AdminGuard } from '@app/common';
 
@@ -16,11 +16,9 @@ export class QuestionController {
 
   @Get() //* QUESTION | Get all ~ {{host}}/question?page=1&limit=10&keywords=keyword
   async getQuestions(
-    @Body() body: ListQuestionsBody,
     @Query() query: ListQuestionsQuery,
   ) {
-    const { keywords, page, limit } = query;
-    const { types, difficulties, source, fields, withExplanation } = body;
+    const { keywords, page, limit, types, difficulties, source, fields, withExplanation } = query;
 
 
     const exam = source ? await this.examService.getExamById(source) : undefined;

--- a/apps/quiz-app/src/module/quiz/dto/question-number.dto.ts
+++ b/apps/quiz-app/src/module/quiz/dto/question-number.dto.ts
@@ -13,7 +13,7 @@ class Field {
     course: string
 }
 
-export class QuestionsNumberBody {
+export class QuestionsNumberQuery {
 
 
     @ValidateNested({ each: true })

--- a/apps/quiz-app/src/module/quiz/quiz.controller.ts
+++ b/apps/quiz-app/src/module/quiz/quiz.controller.ts
@@ -63,11 +63,12 @@ export class QuizController {
   @Get('number') //* QUIZ | Question number ~ {{host}}/quiz/number
   async getQuizNumber(
     @CurrentUser() userId: Types.ObjectId,
-    @Query() body: QuestionsNumberQuery,
+    @Query() queries: QuestionsNumberQuery,
   ) {
 
+    console.log(queries);
 
-    const { fields, difficulties, types, alreadyAnsweredFalse, withExplanation, withNotes } = body
+    const { fields, difficulties, types, alreadyAnsweredFalse, withExplanation, withNotes } = queries
 
     const ids = []
 

--- a/apps/quiz-app/src/module/quiz/quiz.controller.ts
+++ b/apps/quiz-app/src/module/quiz/quiz.controller.ts
@@ -9,7 +9,7 @@ import { ListQuizQuery } from './dto/list-quiz.dto';
 import { UpdateQuizBody } from './dto/update-quiz.dto';
 import { PaginationQuery } from '@app/common/utils/pagination';
 import { NotesService } from '../notes/notes.service';
-import { QuestionsNumberBody } from './dto/question-number.dto';
+import { QuestionsNumberQuery } from './dto/question-number.dto';
 
 @Controller('quiz')
 @UseGuards(HttpAuthGuard)
@@ -63,8 +63,10 @@ export class QuizController {
   @Get('number') //* QUIZ | Question number ~ {{host}}/quiz/number
   async getQuizNumber(
     @CurrentUser() userId: Types.ObjectId,
-    @Body() body: QuestionsNumberBody,
+    @Query() body: QuestionsNumberQuery,
   ) {
+
+
     const { fields, difficulties, types, alreadyAnsweredFalse, withExplanation, withNotes } = body
 
     const ids = []


### PR DESCRIPTION
Changed the DTO class name from `QuestionsNumberBody` to `QuestionsNumberQuery` and updated the associated controller method to use query parameters instead of request body. This adjustment aligns with the HTTP GET method's standard practices, improving the API's usability and compliance with RESTful principles. Now, quiz number requests are more intuitive and streamlined for clients.

No issue references provided.